### PR TITLE
chore: window용 env load 서버 실행 sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ bin/
 CLAUDE.md
 
 .env
+
+server_start.sh


### PR DESCRIPTION
window에서 godotenv 실행 성공 미보장으로 인해 env load 실패함.

그래서 server_start.sh을 따로 실행하고, 해당 sh은 ignore로 관리.